### PR TITLE
Add missing symlink for stripper to the kernel toolchain

### DIFF
--- a/bin/aarch64-linux-androidkernel-strip
+++ b/bin/aarch64-linux-androidkernel-strip
@@ -1,0 +1,1 @@
+aarch64-linux-android-strip


### PR DESCRIPTION
Change-Id: I942415a5dedb1abb13196306f17092ad4b44feaf
Signed-off-by: Alex Naidis <alex.naidis@linux.com>